### PR TITLE
Eval & publish harness: notebook-free test eval (metrics.json + plots)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,22 @@
+name: smoke
+on:
+  pull_request:
+    branches: [ master, main ]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install minimal deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ultralytics>=8.3,<9" numpy opencv-python-headless matplotlib pandas pyyaml
+      - name: Import smoke test
+        run: |
+          python - <<'PY'
+          import ultralytics, numpy, cv2, matplotlib, pandas, yaml
+          print("Imports OK")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+outputs/
+*.pyc
+__pycache__/
+.venv/

--- a/data.yaml
+++ b/data.yaml
@@ -1,0 +1,5 @@
+# data.yaml (4 classes you care about)
+path: data
+train: train/images
+val:   val/images
+names: [ship, buoy, fishnet_buoy, lighthouse]   # IDs 0..3

--- a/docs/EVAL_QUICKSTART.md
+++ b/docs/EVAL_QUICKSTART.md
@@ -1,0 +1,12 @@
+# Quickstart — Test-set Evaluation (no notebooks)
+
+1) Activate env (VM or local):  
+   `python3 -m venv ~/.venv-seaqr && source ~/.venv-seaqr/bin/activate && pip install "ultralytics>=8.3,<9" numpy opencv-python-headless matplotlib pandas pyyaml`
+2) Set variables:  
+   `export RUN_ID=yolo_run_20250919_212059`  
+   `export WEIGHTS=gs://seaqr-ml-seaqr-detection-123-us-central1/backups/weights/best.pt`  
+   `export DATASET_YAML=/data/dataset/data.yaml`    # VM path (or local path if you copied test split)
+3) Run eval: `bash scripts/val_test.sh`
+4) Publish (optional):  
+   `export PUBLISH=gs://seaqr-detection-data-roman/test_results/$RUN_ID/ && bash scripts/publish.sh`
+Outputs appear under `outputs/$RUN_ID/` → `metrics.json`, `plots/`, `results.csv`.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+RUN_ID="${RUN_ID:?set RUN_ID}"
+OUTDIR="outputs/${RUN_ID}"
+PUBLISH="${PUBLISH:?set PUBLISH}"  # e.g., gs://seaqr-detection-data-roman/test_results/${RUN_ID}/
+gsutil -m rsync -r "${OUTDIR}" "${PUBLISH}"
+echo "Published to ${PUBLISH}"

--- a/scripts/val_test.sh
+++ b/scripts/val_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# REQUIRED env:
+#   RUN_ID         e.g., yolo_run_20250919_212059 or test_eval_$(date +%F)
+#   WEIGHTS        local path or gs://.../best.pt
+#   DATASET_YAML   e.g., /data/dataset/data.yaml (on the VM) or a local path
+# OPTIONAL:
+#   IMG_SIZE (1280)  CONF (0.001)  IOU (0.6)  DEVICE (0|cpu)
+
+RUN_ID="${RUN_ID:?set RUN_ID}"; WEIGHTS="${WEIGHTS:?set WEIGHTS}"; DATASET_YAML="${DATASET_YAML:?set DATASET_YAML}"
+IMG_SIZE="${IMG_SIZE:-1280}"; CONF="${CONF:-0.001}"; IOU="${IOU:-0.6}"; DEVICE="${DEVICE:-0}"
+OUTDIR="outputs/${RUN_ID}"; mkdir -p "${OUTDIR}"
+
+# If WEIGHTS is a GCS path, copy local for stability
+if [[ "${WEIGHTS}" == gs://* ]]; then
+  gsutil cp "${WEIGHTS}" "${OUTDIR}/best.pt"
+  WEIGHTS="${OUTDIR}/best.pt"
+fi
+
+# Run Ultralytics (>=8.3). Use python -m to avoid PATH issues with 'yolo'
+python -m ultralytics val \
+  model="${WEIGHTS}" data="${DATASET_YAML}" split=test \
+  imgsz="${IMG_SIZE}" conf="${CONF}" iou="${IOU}" device="${DEVICE}" \
+  project="${OUTDIR}" name="val_test" plots=True save_json=True
+
+# Summarize to metrics.json
+python - <<'PY'
+import csv, json, pathlib, sys, datetime
+out = pathlib.Path(sys.argv[1])/'val_test'
+row = list(csv.DictReader((out/'results.csv').open()))[-1]
+def f(x): 
+  try: return float(x)
+  except: return None
+metrics = {"timestamp": datetime.datetime.utcnow().isoformat()+"Z",
+           "mAP50": f(row.get("metrics/mAP50")),
+           "mAP50-95": f(row.get("metrics/mAP50-95")),
+           "precision": f(row.get("metrics/precision")),
+           "recall": f(row.get("metrics/recall")),
+           "raw": row}
+(out.parent/'metrics.json').write_text(json.dumps(metrics, indent=2))
+print("Wrote", out.parent/'metrics.json')
+PY
+echo "Done → ${OUTDIR}/metrics.json and ${OUTDIR}/val_test/plots/"


### PR DESCRIPTION
# Quickstart — Test-set Evaluation (no notebooks)

1) Activate env (VM or local):  
   `python3 -m venv ~/.venv-seaqr && source ~/.venv-seaqr/bin/activate && pip install "ultralytics>=8.3,<9" numpy opencv-python-headless matplotlib pandas pyyaml`
2) Set variables:  
   `export RUN_ID=yolo_run_20250919_212059`  
   `export WEIGHTS=gs://seaqr-ml-seaqr-detection-123-us-central1/backups/weights/best.pt`  
   `export DATASET_YAML=/data/dataset/data.yaml`    # VM path (or local path if you copied test split)
3) Run eval: `bash scripts/val_test.sh`
4) Publish (optional):  
   `export PUBLISH=gs://seaqr-detection-data-roman/test_results/$RUN_ID/ && bash scripts/publish.sh`
Outputs appear under `outputs/$RUN_ID/` → `metrics.json`, `plots/`, `results.csv`.
